### PR TITLE
Add CRUD service classes for every entity

### DIFF
--- a/apps/assolutions-back/src/crud/account.service.ts
+++ b/apps/assolutions-back/src/crud/account.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Account } from '../entities/compte.entity';
+
+@Injectable()
+export class AccountService {
+  constructor(
+    @InjectRepository(Account)
+    private readonly repo: Repository<Account>,
+  ) {}
+
+  async get(id: number): Promise<Account> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('ACCOUNT_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Account[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Account>): Promise<Account> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Account>): Promise<Account> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/course.service.ts
+++ b/apps/assolutions-back/src/crud/course.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Course } from '../entities/cours.entity';
+
+@Injectable()
+export class CourseService {
+  constructor(
+    @InjectRepository(Course)
+    private readonly repo: Repository<Course>,
+  ) {}
+
+  async get(id: number): Promise<Course> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('COURSE_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Course[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Course>): Promise<Course> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Course>): Promise<Course> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/courseprofessor.service.ts
+++ b/apps/assolutions-back/src/crud/courseprofessor.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { CourseProfessor } from '../entities/cours_professeur.entity';
+
+@Injectable()
+export class CourseProfessorService {
+  constructor(
+    @InjectRepository(CourseProfessor)
+    private readonly repo: Repository<CourseProfessor>,
+  ) {}
+
+  async get(id: number): Promise<CourseProfessor> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('COURSEPROFESSOR_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<CourseProfessor[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<CourseProfessor>): Promise<CourseProfessor> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<CourseProfessor>): Promise<CourseProfessor> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/document.service.ts
+++ b/apps/assolutions-back/src/crud/document.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Document } from '../entities/document.entity';
+
+@Injectable()
+export class DocumentService {
+  constructor(
+    @InjectRepository(Document)
+    private readonly repo: Repository<Document>,
+  ) {}
+
+  async get(id: number): Promise<Document> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('DOCUMENT_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Document[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Document>): Promise<Document> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Document>): Promise<Document> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/group.service.ts
+++ b/apps/assolutions-back/src/crud/group.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Group } from '../entities/groupe.entity';
+
+@Injectable()
+export class GroupService {
+  constructor(
+    @InjectRepository(Group)
+    private readonly repo: Repository<Group>,
+  ) {}
+
+  async get(id: number): Promise<Group> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('GROUP_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Group[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Group>): Promise<Group> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Group>): Promise<Group> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/inscriptionsaison.service.ts
+++ b/apps/assolutions-back/src/crud/inscriptionsaison.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { InscriptionSaison } from '../entities/inscription-saison.entity';
+
+@Injectable()
+export class InscriptionSaisonService {
+  constructor(
+    @InjectRepository(InscriptionSaison)
+    private readonly repo: Repository<InscriptionSaison>,
+  ) {}
+
+  async get(id: number): Promise<InscriptionSaison> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('INSCRIPTIONSAISON_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<InscriptionSaison[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<InscriptionSaison>): Promise<InscriptionSaison> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<InscriptionSaison>): Promise<InscriptionSaison> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/inscriptionseance.service.ts
+++ b/apps/assolutions-back/src/crud/inscriptionseance.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { InscriptionSeance } from '../entities/inscription-seance.entity';
+
+@Injectable()
+export class InscriptionSeanceService {
+  constructor(
+    @InjectRepository(InscriptionSeance)
+    private readonly repo: Repository<InscriptionSeance>,
+  ) {}
+
+  async get(id: number): Promise<InscriptionSeance> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('INSCRIPTIONSEANCE_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<InscriptionSeance[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<InscriptionSeance>): Promise<InscriptionSeance> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<InscriptionSeance>): Promise<InscriptionSeance> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/linkgroup.service.ts
+++ b/apps/assolutions-back/src/crud/linkgroup.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { LinkGroup } from '../entities/lien_groupe.entity';
+
+@Injectable()
+export class LinkGroupService {
+  constructor(
+    @InjectRepository(LinkGroup)
+    private readonly repo: Repository<LinkGroup>,
+  ) {}
+
+  async get(id: number): Promise<LinkGroup> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('LINKGROUP_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<LinkGroup[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<LinkGroup>): Promise<LinkGroup> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<LinkGroup>): Promise<LinkGroup> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/location.service.ts
+++ b/apps/assolutions-back/src/crud/location.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Location } from '../entities/lieu.entity';
+
+@Injectable()
+export class LocationService {
+  constructor(
+    @InjectRepository(Location)
+    private readonly repo: Repository<Location>,
+  ) {}
+
+  async get(id: number): Promise<Location> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('LOCATION_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Location[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Location>): Promise<Location> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Location>): Promise<Location> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/person.service.ts
+++ b/apps/assolutions-back/src/crud/person.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Person } from '../entities/personne.entity';
+
+@Injectable()
+export class PersonService {
+  constructor(
+    @InjectRepository(Person)
+    private readonly repo: Repository<Person>,
+  ) {}
+
+  async get(id: number): Promise<Person> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('PERSON_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Person[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Person>): Promise<Person> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Person>): Promise<Person> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/professor.service.ts
+++ b/apps/assolutions-back/src/crud/professor.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Professor } from '../entities/professeur.entity';
+
+@Injectable()
+export class ProfessorService {
+  constructor(
+    @InjectRepository(Professor)
+    private readonly repo: Repository<Professor>,
+  ) {}
+
+  async get(id: number): Promise<Professor> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('PROFESSOR_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Professor[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Professor>): Promise<Professor> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Professor>): Promise<Professor> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/professorcontract.service.ts
+++ b/apps/assolutions-back/src/crud/professorcontract.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { ProfessorContract } from '../entities/contrat_prof.entity';
+
+@Injectable()
+export class ProfessorContractService {
+  constructor(
+    @InjectRepository(ProfessorContract)
+    private readonly repo: Repository<ProfessorContract>,
+  ) {}
+
+  async get(id: number): Promise<ProfessorContract> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('PROFESSORCONTRACT_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<ProfessorContract[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<ProfessorContract>): Promise<ProfessorContract> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<ProfessorContract>): Promise<ProfessorContract> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/project.service.ts
+++ b/apps/assolutions-back/src/crud/project.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Project } from '../entities/projet.entity';
+
+@Injectable()
+export class ProjectService {
+  constructor(
+    @InjectRepository(Project)
+    private readonly repo: Repository<Project>,
+  ) {}
+
+  async get(id: number): Promise<Project> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('PROJECT_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Project[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Project>): Promise<Project> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Project>): Promise<Project> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/seanceprofesseur.service.ts
+++ b/apps/assolutions-back/src/crud/seanceprofesseur.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { SeanceProfesseur } from '../entities/seance-professeur.entity';
+
+@Injectable()
+export class SeanceProfesseurService {
+  constructor(
+    @InjectRepository(SeanceProfesseur)
+    private readonly repo: Repository<SeanceProfesseur>,
+  ) {}
+
+  async get(id: number): Promise<SeanceProfesseur> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('SEANCEPROFESSEUR_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<SeanceProfesseur[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<SeanceProfesseur>): Promise<SeanceProfesseur> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<SeanceProfesseur>): Promise<SeanceProfesseur> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/season.service.ts
+++ b/apps/assolutions-back/src/crud/season.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Season } from '../entities/saison.entity';
+
+@Injectable()
+export class SeasonService {
+  constructor(
+    @InjectRepository(Season)
+    private readonly repo: Repository<Season>,
+  ) {}
+
+  async get(id: number): Promise<Season> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('SEASON_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Season[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Season>): Promise<Season> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Season>): Promise<Season> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}

--- a/apps/assolutions-back/src/crud/session.service.ts
+++ b/apps/assolutions-back/src/crud/session.service.ts
@@ -1,0 +1,49 @@
+
+import { Injectable, BadRequestException, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
+import { Session } from '../entities/seance.entity';
+
+@Injectable()
+export class SessionService {
+  constructor(
+    @InjectRepository(Session)
+    private readonly repo: Repository<Session>,
+  ) {}
+
+  async get(id: number): Promise<Session> {
+    const item = await this.repo.findOne({ where: { id } });
+    if (!item) throw new NotFoundException('SESSION_NOT_FOUND');
+    return item;
+  }
+
+  async getAll(): Promise<Session[]> {
+    return this.repo.find();
+  }
+
+  async create(data: Partial<Session>): Promise<Session> {
+    try {
+      const created = this.repo.create(data);
+      return await this.repo.save(created);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+  }
+
+  async update(id: number, data: Partial<Session>): Promise<Session> {
+    await this.get(id);
+    try {
+      await this.repo.update({ id }, data);
+    } catch (err) {
+      if (err instanceof QueryFailedError) throw new BadRequestException('INTEGRITY_ERROR');
+      throw err;
+    }
+    return this.get(id);
+  }
+
+  async delete(id: number): Promise<void> {
+    await this.get(id);
+    await this.repo.delete({ id });
+  }
+}


### PR DESCRIPTION
## Summary
- add CRUD service classes for every entity in `assolutions-back`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ccc3225a88328933087215c7fdac9